### PR TITLE
fix scheduler step

### DIFF
--- a/models/pytorch_geometric/example.py
+++ b/models/pytorch_geometric/example.py
@@ -58,7 +58,7 @@ class Net(torch.nn.Module):
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model = Net().to(device)
 optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
-scheduler = ReduceLROnPlateau(optimizer, mode='min', factor=0.5, patience=20, min_lr=0.0001)
+scheduler = ReduceLROnPlateau(optimizer, mode='max', factor=0.5, patience=20, min_lr=0.0001)
 
 
 def train(epoch):


### PR DESCRIPTION
Hi,
I think that the mode of the scheduler should be 'max' for `val_roc` metric in the `pytorch_geometric/example.py`.